### PR TITLE
Rename main path from umd/slideToggle.js to umd/slidetoggle.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ btn.addEventListener('click', () => {
             <button class="btn">Click me</button>
             <div class="toggle-div">Click on button will toggle my height</div>
         </body>
-        <script src="node_modules/slidetoggle/umd/slideToggle.min.js"></script>
+        <script src="node_modules/slidetoggle/umd/slidetoggle.min.js"></script>
         <script>
             const myVar = Slidetoggle.slideToggle;
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "slidetoggle",
   "version": "1.2.0",
   "description": "Small library that replaces the so-loved jQuery function",
-  "main": "umd/slideToggle.js",
+  "main": "umd/slidetoggle.js",
   "module": "lib/index.js",
   "es2015": "lib-esm/index.js",
   "typings": "typings/index.d.ts",


### PR DESCRIPTION
The umd output filename is `[name].js` from [UMDConfig](https://github.com/proshunsuke/slideToggle/blob/01fd1e7ad9b9c5b190b2321bfe3a8fadd624381b/webpack.config.js#L98), and `[name]` is [name in package.json](https://github.com/proshunsuke/slideToggle/blob/9711016132fc1b361759541e6f8cd8a55ccf3e30/package.json#L2).
So, the output is as follows.

```bash
> tree umd/
umd/
├── slidetoggle.js
├── slidetoggle.js.map
├── slidetoggle.min.js
└── slidetoggle.min.js.map
```

But, main in package.json is `umd/slideToggle.js` . This will cause an error when referenced by other tools [like this](https://github.com/yarnpkg/berry/blob/e86f23989c58a7f554bebcb224815c105562bc35/packages/yarnpkg-pnp/sources/loader/makeApi.ts#L197-L203).

So, I renamed main path from `umd/slideToggle.js` to `umd/slidetoggle.js` .
